### PR TITLE
3/12 Update: Revised main.c, made can_manager.c/h

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,19 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "windows-msvc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "can_manager.h": "c"
+    }
+}

--- a/alpaca-bms-FE9_Rev2/alpaca-bms-FE9_Rev2.cydsn/alpaca-bms-FE9_Rev2.cyprj
+++ b/alpaca-bms-FE9_Rev2/alpaca-bms-FE9_Rev2.cydsn/alpaca-bms-FE9_Rev2.cyprj
@@ -39,6 +39,13 @@
 <build_action v="SOURCE_C;;;;" />
 <PropertyDeltas />
 </CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b>
+<CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtFileSerialize" version="3" xml_contents_version="1">
+<CyGuid_31768f72-0253-412b-af77-e7dba74d1330 type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtItemSerialize" version="2" name="can_manager.c" persistent="can_manager.c">
+<Hidden v="False" />
+</CyGuid_31768f72-0253-412b-af77-e7dba74d1330>
+<build_action v="SOURCE_C;;;;" />
+<PropertyDeltas />
+</CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b>
 </dependencies>
 </CyGuid_0820c2e7-528d-4137-9a08-97257b946089>
 </CyGuid_2f73275c-45bf-46ba-b3b1-00a2fe0c8dd8>
@@ -79,6 +86,13 @@
 </CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b>
 <CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtFileSerialize" version="3" xml_contents_version="1">
 <CyGuid_31768f72-0253-412b-af77-e7dba74d1330 type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtItemSerialize" version="2" name="cell_interface.h" persistent="cell_interface.h">
+<Hidden v="False" />
+</CyGuid_31768f72-0253-412b-af77-e7dba74d1330>
+<build_action v="HEADER;;;;" />
+<PropertyDeltas />
+</CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b>
+<CyGuid_8b8ab257-35d3-4473-b57b-36315200b38b type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtFileSerialize" version="3" xml_contents_version="1">
+<CyGuid_31768f72-0253-412b-af77-e7dba74d1330 type_name="CyDesigner.Common.ProjMgmt.Model.CyPrjMgmtItemSerialize" version="2" name="can_manager.h" persistent="can_manager.h">
 <Hidden v="False" />
 </CyGuid_31768f72-0253-412b-af77-e7dba74d1330>
 <build_action v="HEADER;;;;" />
@@ -1569,6 +1583,6 @@
 <ignored_deps />
 </CyGuid_495451fe-d201-4d01-b22d-5d3f5609ac37>
 <boot_component v="" />
-<current_generation v="3" />
+<current_generation v="5" />
 </CyGuid_fec8f9e8-2365-4bdb-96d3-a4380222e01b>
 </CyXmlSerializer>

--- a/alpaca-bms-FE9_Rev2/alpaca-bms-FE9_Rev2.cydsn/can_manager.c
+++ b/alpaca-bms-FE9_Rev2/alpaca-bms-FE9_Rev2.cydsn/can_manager.c
@@ -1,0 +1,99 @@
+/* ========================================
+ *
+ * Copyright YOUR COMPANY, THE YEAR
+ * All Rights Reserved
+ * UNPUBLISHED, LICENSED SOFTWARE.
+ *
+ * CONFIDENTIAL AND PROPRIETARY INFORMATION
+ * WHICH IS THE PROPERTY OF your company.
+ *
+ * ========================================
+*/
+
+#include "can_manager.h"
+
+#include "cell_interface.h"
+
+volatile uint8_t can_buffer[8];
+extern BAT_PACK_t bat_pack;
+extern volatile uint8_t CAN_DEBUG;
+
+/* Data Frame format for Voltage and Temperature
+The datatype consists of three bytes:
+1. Identifying Number (eg cell #1)
+2. upper byte of data
+3. lower byte of data
+*/
+
+
+void can_send_temp(volatile BAT_SUBPACK_t *subpacks[N_OF_SUBPACK],
+    volatile uint8_t high_tempNode,
+    volatile uint8_t high_temp)
+{
+    for (unsigned int i = 0; i < N_OF_SUBPACK; i++) {
+        can_buffer[i] = subpacks[i]->high_temp; //I'm not quite sure I sent in the correct parameter to access this. Could you check this?
+    }    
+    can_buffer[6] = 0xff & high_tempNode;
+    can_buffer[7] = high_temp; //(high_temp/10)<<4 | (high_temp%10);
+
+    //This works in the case that the number of subpacks is
+
+	CAN_1_SendMsgtemp();
+    CyDelay(5);
+} // can_send_temp() 
+
+
+void can_send_volt(
+    volatile uint16_t min_voltage,
+    volatile uint16_t max_voltage,
+    volatile uint32_t pack_voltage)
+{
+    //max and min voltage means the voltage of single cell
+        can_buffer[0] = HI8(min_voltage);
+        can_buffer[1] = LO8(min_voltage);
+
+        can_buffer[2] = HI8(max_voltage);
+        can_buffer[3] = LO8(max_voltage);
+
+        can_buffer[4] = 0xFF & (pack_voltage >> 24);
+        can_buffer[5] = 0xFF & (pack_voltage >> 16);
+        can_buffer[6] = 0xFF & (pack_voltage >> 8);
+        can_buffer[7] = 0xFF & (pack_voltage);
+
+
+        CAN_1_SendMsgvolt();
+        CyDelay(1);
+
+} // can_send_volt()
+
+
+void can_send_status(volatile uint8_t name,
+                    volatile uint8_t SOC_P,
+                    volatile uint16_t status,
+                    volatile uint8_t stack,
+                    volatile uint8_t cell,
+                    volatile uint16_t value16){
+//8 SOC Percent
+//8 AH used since full charge
+//16 BMS Status bits (error flags)
+//16 Number of charge cycles
+//16 Pack balance (delta) mV
+    can_buffer[0] = name;
+    can_buffer[1] = (uint8_t)(SOC_P/10)<<4 | (uint8_t)(SOC_P%10);
+    can_buffer[2] = HI8(status);
+    can_buffer[3] = LO8(status);
+    can_buffer[4] = stack & 0xFF;
+    can_buffer[5] = (cell) & 0xFF;
+    can_buffer[6] = HI8(value16);
+    can_buffer[7] = LO8(value16);
+
+    CAN_1_SendMsgstatus();
+}
+
+void can_init()
+{
+	CAN_1_GlobalIntEnable(); // CAN Initialization
+	CAN_1_Init();
+	CAN_1_Start();
+} // can_init(
+/* [] END OF FILE */

--- a/alpaca-bms-FE9_Rev2/alpaca-bms-FE9_Rev2.cydsn/can_manager.h
+++ b/alpaca-bms-FE9_Rev2/alpaca-bms-FE9_Rev2.cydsn/can_manager.h
@@ -1,0 +1,44 @@
+/* ========================================
+ *
+ * Copyright YOUR COMPANY, THE YEAR
+ * All Rights Reserved
+ * UNPUBLISHED, LICENSED SOFTWARE.
+ *
+ * CONFIDENTIAL AND PROPRIETARY INFORMATION
+ * WHICH IS THE PROPERTY OF your company.
+ *
+ * ========================================
+*/
+#ifndef CAN_MANAGER_H
+#define CAN_MANAGER_H
+
+#include <project.h>
+#include "data.h"
+#include "LTC6811.h"
+#include "cell_interface.h"
+
+
+
+
+void can_send_temp(volatile BAT_SUBPACK_t *subpacks[N_OF_SUBPACK],
+    uint8_t high_tempNode,
+    uint8_t high_temp);
+
+void can_send_volt(
+    uint16_t min_voltage,
+    uint16_t max_voltage,
+    uint32_t pack_voltage);
+
+//void can_send_current(int16_t battery_current) is now obsolete
+
+void can_send_status(uint8_t name,
+                    uint8_t SOC_P,
+                    uint16_t status,
+                    uint8_t stack,
+                    uint8_t cell,
+                    uint16_t value16);
+
+void can_init();
+
+#endif // CAN_MANAGER_H
+/* [] END OF FILE */

--- a/alpaca-bms-FE9_Rev2/alpaca-bms-FE9_Rev2.cydsn/cell_interface.c
+++ b/alpaca-bms-FE9_Rev2/alpaca-bms-FE9_Rev2.cydsn/cell_interface.c
@@ -16,7 +16,7 @@
 void cell_interface_init(){
     LTC6811_init_cfg();
 }
-/*
+
 void  bms_init(uint8_t adc_mode){
     SS_SetDriveMode(SS_DM_RES_UP);
     LTC68_Start();
@@ -25,7 +25,7 @@ void  bms_init(uint8_t adc_mode){
     LTC6804_wrcfg(IC_PER_BUS, tx_cfg);
     //Select6820_Write(1);
     //LTC6804_wrcfg(IC_PER_BUS, tx_cfg);
-}*/
+}
 
 void get_all_temps(){
     uint16_t temps[N_OF_LTC][TEMPS_PER_LTC];


### PR DESCRIPTION
main.c - Added global variables from the old version and tried to comment out ones that seemed obsolete or not needed(needs revision). Also tried to rewrite can_send_temp() for a dynamic number of subpacks, and changed code for time so it measured the time of cycle(used in Kalman Filter for SOC est.)

can_manager.c - Copied from the old version of the code on the FRUCD github repos and needed for the can functions in main.c. Deleted functions relating to current and attempted to rewrite the can_send_temp() function.

can_manager.h - Also copied from the old code, made changes according to the changes in can_manager.c and deleted an enum that was in conflict from cell_interface.h that needed to be included for the BAT_SUBPACK_t struct to be defined in the can_send_temp function.

Also, this version has around 10 errors in LTC6811.h, mostly about "redefining" or "redeclaring" certain things.